### PR TITLE
Make JS and Sass optional in Modernizr task

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,18 @@ npm install grrr-gulpfile --save-dev
 
 ### Configure
 1. Create a `gulp.json` config file (see [below](#task-configuration)).
-2. Add the required Babel dependencies for your project. A good starting point is by adding `@babel/preset-env`. See the [Babel docs](https://babeljs.io/docs/plugins/preset-env/) for more information. Now specify the Babel config in the `gulp.json`. See [below](#config-file) for an example, or check the [Babel docs](https://babeljs.io/docs/usage/babelrc/) for more information.
+2. Add the required Babel dependencies for your project. A good starting point is by adding `@babel/preset-env`.
+
+```
+npm install --save-dev @babel/preset-env
+```
+
+See the [Babel docs](https://babeljs.io/docs/plugins/preset-env/) for more information. Now specify the Babel config in the `gulp.json`. See [the advanced example](https://github.com/grrr-amsterdam/gulpfile/blob/master/examples/config-advanced.json#L35) for an example, or check the [Babel docs](https://babeljs.io/docs/usage/babelrc/) for more information.
 
 ### Run
 Run gulp by calling:
 ```
-gulp --cwd . --gulpfile 'node_modules/grrr-gulpfile/gulpfile.babel.js'
+gulp --cwd . --gulpfile 'node_modules/grrr-gulpfile/gulpfile.js'
 ```
 
 Tip: save this as an npm script in your project's `package.json`, for example:

--- a/tasks/modernizr.js
+++ b/tasks/modernizr.js
@@ -19,8 +19,8 @@ gulp.task('modernizr', (done) => {
   }
   pump([
     gulp.src([
-      config.get('tasks.sass.src'),
-      config.get('tasks.javascript.src'),
+      config.get('tasks.sass.src') || '',
+      config.get('tasks.javascript.src') || '',
       '!**/{vendor,polyfills}/**/*.js',
     ]),
     modernizr({


### PR DESCRIPTION
This fixes the Gulpfile when only JS or only Sass is required.

The check at the top of the Modernizr task will skip the function when both JS and
Sass are disabled, but if _either_ of them is enabled, _both_ paths will
be added, resulting in a faulty glob if one of them is not defined.

This also fixes some documentation to make the Getting Started procedure a little more copy-pastable.