### PR TITLE
Add Closure Compiler to minify JavaScript

### DIFF
--- a/examples/config-advanced.json
+++ b/examples/config-advanced.json
@@ -24,13 +24,12 @@
     "javascript": {
       "src": "assets/scripts/**/*.js",
       "dist": "dist/scripts",
-      "main": [
-        "assets/scripts/main.js"
-      ],
+      "main": "assets/scripts/main.js",
       "bundles": [
         {
-          "bundle": "main.js",
+          "bundle": "bundle.js",
           "watch": true,
+          "minify": true,
           "babelify": {
             "global": true
           },
@@ -62,7 +61,7 @@
           }
         },
         {
-          "bundle": "main-legacy.js",
+          "bundle": "bundle-legacy.js",
           "watch": false,
           "babel": {
             "plugins": [

--- a/examples/config-basic.json
+++ b/examples/config-basic.json
@@ -18,13 +18,12 @@
     "javascript": {
       "src": "assets/scripts/**/*.js",
       "dist": "dist/scripts",
-      "main": [
-        "assets/scripts/main.js"
-      ],
+      "main": "assets/scripts/main.js",
       "bundles": [
         {
-          "bundle": "main.js",
+          "bundle": "bundle.js",
           "watch": true,
+          "minify": true,
           "babelify": {
             "global": true
           },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-import": "^2.7.0",
     "esmify": "^2.0.0",
     "fancy-log": "^1.3.2",
+    "google-closure-compiler": "^20190121.0.0",
     "gulp": "^4.0.0",
     "gulp-babel": "^8.0.0",
     "gulp-clean-css": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3696,6 +3696,41 @@ gonzales-pe-sl@^4.2.3:
   dependencies:
     minimist "1.1.x"
 
+google-closure-compiler-java@^20190121.0.0:
+  version "20190121.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20190121.0.0.tgz#f81dc90adb13a6ee49b430df628eecc22c69e3bd"
+  integrity sha512-UCQ7ZXOlk/g101DS4TqyW+SaoR+4GVq7NKrwebH4gnESY76Xuz7FRrKWwfAXwltmiYAUVZCVI4qpoEz48V+VjA==
+
+google-closure-compiler-js@^20190121.0.0:
+  version "20190121.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20190121.0.0.tgz#c59d1d2093525328d74ab27b563444a4b88507c7"
+  integrity sha512-PgY0Fy+fXZnjir6aPz/FVJPXuwZf5pKJ9n7Hf1HL4x1lhqVIf3i+u3Ed6ZWCXa+YiEhvwH5RTQr/iPP/D3gDRg==
+
+google-closure-compiler-linux@^20190121.0.0:
+  version "20190121.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-linux/-/google-closure-compiler-linux-20190121.0.0.tgz#bc6b886715d8271d5c1cebacb26c3305fbd1b952"
+  integrity sha512-cw4qr9TuB2gB53l/oYadZLuw+zOi2yggYFtnNA5jvTLTqY8m2VZAL5DGL6gmCtZovbQ0bv9ANqjT8NxEtcSzfw==
+
+google-closure-compiler-osx@^20190121.0.0:
+  version "20190121.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-osx/-/google-closure-compiler-osx-20190121.0.0.tgz#cd480814d44bf86a64f6ed4e700004905e91ed65"
+  integrity sha512-6OqyUcgojPCqCuzdyKLwmIkBhfoWF3cVzaX8vaJvQ3SYwlITBT3aepMEZiWFRVvvml+ojs1AJcZvQIqFke8X1w==
+
+google-closure-compiler@^20190121.0.0:
+  version "20190121.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler/-/google-closure-compiler-20190121.0.0.tgz#6f2d5bfe58552407a7f25abe6f891626e0bfe4f3"
+  integrity sha512-FIp3+KxjtDwykDTr1WsFo0QexEopAC4bDXXZfnEdgHECF7hCeFAAsLUPxMmj9Wx+O39eFCXGAzY7w0k5aU9qjg==
+  dependencies:
+    chalk "^1.0.0"
+    google-closure-compiler-java "^20190121.0.0"
+    google-closure-compiler-js "^20190121.0.0"
+    minimist "^1.2.0"
+    vinyl "^2.0.1"
+    vinyl-sourcemaps-apply "^0.2.0"
+  optionalDependencies:
+    google-closure-compiler-linux "^20190121.0.0"
+    google-closure-compiler-osx "^20190121.0.0"
+
 got@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/got/-/got-7.1.0.tgz#05450fd84094e6bbea56f451a43a9c289166385a"


### PR DESCRIPTION
Adds the Google Closure Compiler, mainly for minification purposes. Globals should be preserved, and somehow the compiler fails when the source input name is the same as the output name.

Performance benefits: around **40-60% size reduction**, even when using `gzip`:

```shell
-rw-r--r--@  1 koen  staff   566K Feb 15 15:58 bundle-old.js
-rw-r--r--@  1 koen  staff   252K Feb 15 15:33 bundle-new.js
```
```shell
-rw-r--r--   1 koen  staff   136K Feb 15 15:58 bundle-old.tar.gz
-rw-r--r--   1 koen  staff    73K Feb 15 15:58 bundle-new.tar.gz
```

I've added it as a simple `minify` entry to the `gulp.json`, and will perform some additional testing before publishing the package. Also the base of this branch should change to `master` when the previous pull request is merged.