### PR TITLE
Allow symbolically linked cwds

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,15 +1,30 @@
 import fs from 'fs';
 import path from 'path';
+import log from 'fancy-log';
 import dotenv from 'dotenv';
 import config from './lib/config';
 
 /**
- * Load environment variables from `.env`
+ * Update `cwd` if `package.json` is a symlink.
+ */
+const packageLocation = fs.realpathSync(path.resolve(process.cwd(), 'package.json'));
+const realPath = path.dirname(packageLocation);
+if (process.cwd() !== realPath) {
+  try {
+    process.chdir(realPath);
+  } catch (error) {
+    log.error(`Unable to switch to symbolic directory: ${error}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Load environment variables from `.env`.
  */
 dotenv.config({ path: config.get('dotenv.file') || process.cwd() });
 
 /**
- * Gulp tasks are defined in separate files in the tasks folder
+ * Gulp tasks are defined in separate files in the tasks folder.
  */
 const taskFolder = path.join(__dirname, 'tasks');
 fs.readdirSync(taskFolder)
@@ -17,6 +32,6 @@ fs.readdirSync(taskFolder)
   .forEach(task => require(path.join(taskFolder, task)));
 
 /**
- * Custom `SIGINT` listener to exit process
+ * Custom `SIGINT` listener to exit process.
  */
 process.on('SIGINT', e => process.exit(1));

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,16 @@
 import fs from 'fs';
+import path from 'path';
+import log from 'fancy-log';
 
-const configFile = JSON.parse(fs.readFileSync('gulp.json'));
+let parsedConfig;
+
+const getParsedConfig = () => {
+  if (!parsedConfig) {
+    const configFile = fs.readFileSync(path.resolve(process.cwd(), 'gulp.json'));
+    parsedConfig = JSON.parse(configFile);
+  }
+  return parsedConfig;
+};
 
 const convertDotStringToObject = (o, s) => {
   s = s.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
@@ -19,8 +29,8 @@ const convertDotStringToObject = (o, s) => {
 
 const config = {
   get(entry) {
-    return convertDotStringToObject(configFile, entry);
-  }
+    return convertDotStringToObject(getParsedConfig(), entry);
+  },
 };
 
 export default config;


### PR DESCRIPTION
This is a quick attempt to fix the issue discussed in https://github.com/grrr-amsterdam/stedelijk-museum/pull/726

~~Since we're importing `config` we need to set parse it later, since the `cwd` hasn't changed on `import`. Not a huge fan, so if you got any better ideas..? It's not horrible though, so could live with it.~~