### PR TITLE
Add new or unrecognized properties to sass-lint config file

### DIFF
--- a/defaults/.sass-lint.yml
+++ b/defaults/.sass-lint.yml
@@ -160,7 +160,10 @@ rules:
   no-misspelled-properties:
     - 1
     -
-      extra-properties: []
+      extra-properties:
+        - blend-mode
+        - overscroll-behavior
+        - text-decoration-skip-ink
 
   no-qualifying-elements:
     - 1


### PR DESCRIPTION
Added a few properties which required the `no-misspelled-properties` ignore rule. 

@MicheleNL any other ones I'm forgetting?