### PR TITLE
Restrict compatible Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 
 matrix:
   include:
-    - node_js: 8
-    - node_js: 10
-    - node_js: 12
+    - node_js: '8'
+    - node_js: '10'
+    - node_js: '13.0.1'
 
 cache:
   yarn: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 This changelog only lists major version changes (breaking), or minor changes important enough to list them here. Check individual releases (tags) and their commits to see unlisted changes.
 
 
+### v7.0.0 (2019-11-05)
+
+#### Restrict Node.js engine versions
+Node.js versions `>= 12.2.0 <= 13.0.0` are now rejected, since they'll throw an error (`ERR_REQUIRE_ESM`) due to the usage of `@grrr/utils`.
+See `12.2.0` change: https://github.com/nodejs/node/pull/27417
+See `13.0.1` change: https://github.com/nodejs/node/pull/29974
+
+
 ### v6.4.0 (2019-02-28)
 
 #### Replace Browserify by Rollup
@@ -98,7 +106,7 @@ This...
 #### Split up JavaScript into ES6 (ES2015+) and legacy versions
 There are two seperate Babel config entries, and two bundle output entries. This means you can have a `main.js` file for evergreen browsers, alongside a `main-legacy.js` file which will serve older browsers. Additionally really old browser can be served a `no-js` version of the website.
 
-#### Removed JavaScript minification
+#### Remove JavaScript minification
 Uglify doesn't work wel with ES6 syntax, and `gulp-uglify` gave errors when running with newer JavaScript syntax (eg. async functions). Since all files should be served with `gzip` (or some newer form of compression) anyhow, this shouldn't hurt much.
 A future release might add something like [babel-minify](https://github.com/babel/minify).
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/grrr-amsterdam/gulpfile/issues"
   },
   "engines": {
-    "node": ">= 8 <= 12",
+    "node": "^8 || ^10 || ^12 <= 12.1.0 || >= 13.0.1",
     "yarn": ">= 1"
   },
   "dependencies": {


### PR DESCRIPTION
We should consider if this idea makes sense. It's not fixing 'the actual problem', but it does fix it in a 'simple manner'. And I've spent quite some time fixing the actual problem. Although maybe the actual problem is Node breaking-changing behaviour in minor (`12.2.0`) and patch (`13.0.1`) versions.

Possible solutions:

- Restrict Node versions, although no guarantee of future problems (easy, it's this PR, but also high impact)
- Remove imported ESM-`memoize` and add it in the package in a util module (easy and least painful)
- Figure out how to still make it work (hard, already spent a lot of time on it)