### PR TITLE
Move memoize function from @grrr/utils to utils module

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { memoize } from '@grrr/utils';
+import { memoize } from './utils';
 
 export const getParsedConfig = memoize(() => {
   const configFile = fs.readFileSync(path.resolve(process.cwd(), 'gulp.json'));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,10 @@
+export const memoize = fn => {
+  const cache = {};
+  return (...args) => {
+    const key = JSON.stringify(args);
+    if (!(key in cache)) {
+      cache[key] = fn(...args);
+    }
+    return cache[key];
+  };
+};

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.0.0",
     "@babel/register": "^7.0.0",
-    "@grrr/utils": "^2.3.0",
     "autoprefixer": "^9.1.3",
     "babel-eslint": "^10.0.1",
     "browser-sync": "^2.18.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,11 +194,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@grrr/utils@^2.3.0":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@grrr/utils/-/utils-2.3.1.tgz#7e06959809201f2808d125be9ceb3ada9385923b"
-  integrity sha512-75pyaZmH1U8pTCPTxXnuO6Jbt83722ItOfxgAQaARF+NbimMVUrQcKBzmA52ltXf9X6zrIfh8bBUhE0LZfnsvA==
-
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz#1e6fe5d8027b1f285dc0d31762f566bccd73d5a9"


### PR DESCRIPTION
This one is up for debate, and fixes `ERR_REQUIRE_ESM` errors in Node.js `> 12.2.0 < 13.0.1`.

See also https://github.com/grrr-amsterdam/gulpfile/pull/20