### PR TITLE
Replace gulp-rev-replace with gulp-rev-rewrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "gulp-postcss": "^8.0.0",
     "gulp-rev": "^9.0.0",
     "gulp-rev-delete-original": "^0.2.3",
-    "gulp-rev-replace": "^0.4.3",
+    "gulp-rev-rewrite": "^3.0.2",
     "gulp-sass": "^4.0.1",
     "gulp-sass-glob": "^1.0.8",
     "gulp-sass-lint": "^1.3.2",

--- a/tasks/revision.js
+++ b/tasks/revision.js
@@ -5,7 +5,7 @@ import config from '../lib/config';
 import pump from 'pump';
 import rev from 'gulp-rev';
 import revDeleteOriginal from 'gulp-rev-delete-original';
-import revReplace from 'gulp-rev-replace';
+import revRewrite from 'gulp-rev-rewrite';
 import { src, dest, task, parallel, series } from 'gulp';
 
 const MANIFEST_DIR = config.get('tasks.revision') && config.get('tasks.revision.manifest.directory')
@@ -55,7 +55,7 @@ const replaceCss = done => {
   }
   return pump([
     src(`${config.get('tasks.sass.dist')}/**/*.css`),
-    revReplace({ manifest: src(MANIFEST_FULL_PATH) }),
+    revRewrite({ manifest: src(MANIFEST_FULL_PATH) }),
     dest(config.get('tasks.sass.dist')),
   ], done);
 };
@@ -70,7 +70,7 @@ const replaceJs = done => {
   }
   return pump([
     src(`${config.get('tasks.javascript.dist')}/**/*.js`),
-    revReplace({ manifest: src(MANIFEST_FULL_PATH) }),
+    revRewrite({ manifest: src(MANIFEST_FULL_PATH) }),
     dest(config.get('tasks.javascript.dist')),
   ], done);
 };


### PR DESCRIPTION
`gulp-rev-replace` is no longer maintained. `gulp-rev-rewrite` is a maintained fork that contains many improvements.