### PR TITLE
Allow pxtorem Autoprefixer defaults adjustments

### DIFF
--- a/examples/config-advanced.json
+++ b/examples/config-advanced.json
@@ -121,6 +121,10 @@
           "not dead",
         ]
       },
+      "pxtorem": {
+        "rootValue": 16,
+        "propWhiteList": ["*"],
+      },
       "cleanCss": {
         "compatibility": "ie11",
         "level": 1

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -15,26 +15,19 @@ import { src, dest, task } from 'gulp';
 
 const AUTOPREFIXER_CONFIG = config.get('tasks.sass.autoprefixer');
 
-const CLEAN_CSS_CONFIG = config.get('tasks.sass.cleanCss')
-  ? config.get('tasks.sass.cleanCss')
-  : {
-    compatibility: 'ie11',
-    level: 1,
-  };
+const PXTOREM_CONFIG = {
+  rootValue: 10,
+  selectorBlackList: [
+    ':root',
+  ],
+  ...config.get('tasks.sass.pxtorem'),
+};
 
-const PROCESSOR_CONFIG = [
-  autoprefixer(AUTOPREFIXER_CONFIG),
-  pxtorem({
-    root_value: 10,
-    unit_precision: 5,
-    prop_white_list: [
-      'font',
-      'font-size',
-    ],
-    replace: false,
-    media_query: false,
-  }),
-];
+const CLEANCSS_CONFIG = {
+  compatibility: 'ie11',
+  level: 1,
+  ...config.get('tasks.sass.cleanCss'),
+};
 
 /**
  * Compile Sass files.
@@ -54,8 +47,11 @@ export const sass = done => {
         process.exit(1);
       }
     }),
-    postcss(PROCESSOR_CONFIG),
-    gulpif(!isDevelopment, cleanCSS(CLEAN_CSS_CONFIG)),
+    postcss([
+      autoprefixer(AUTOPREFIXER_CONFIG),
+      pxtorem(PXTOREM_CONFIG),
+    ]),
+    gulpif(!isDevelopment, cleanCSS(CLEANCSS_CONFIG)),
     dest(config.get('tasks.sass.dist')),
     browserSync.reload({ stream: true }),
   ], done);


### PR DESCRIPTION
- Allows you to adjust the [pxtorem](https://github.com/cuth/postcss-pxtorem) config. For example when your font-size is the default `16px`, instead of the [62.5% one](https://github.com/grrr-amsterdam/wordpress-scaffold/blob/master/web/app/themes/wordpress-scaffold/assets/styles/base.scss#L43) from the scaffold. Meaning other people can use this thing too 😅 
- Updates outdated pxtorem properties (which apparently still worked), most are defaults now anyway.
- Updates the advanced config with a common use case example.
- Added a `selectorBlackList` entry for `:root:`, since that the 'root' (hence 'relative to font-size of the root element').
- Spreads those refinements, instead of having to specify/overwrite everything.
- Shouldn't break GRRR-stuff, as far as I can tell 👋 

Backstory: used webpack and Rollup for two projects, but those two are still more 'main entry'-based JS compilers. I still like Rollup, although webpack is more flexible regarding tasks. Parcel feels configy/magic... so the `@grrr/gulpfile` came into the picture again. Worked like a charm. Except this one, and possibly the copying task — might get a PR later...