### PR TITLE
Remove unneeded animation stylelint rule

### DIFF
--- a/defaults/.stylelintrc
+++ b/defaults/.stylelintrc
@@ -29,7 +29,6 @@
     "no-duplicate-selectors": true,
     "no-empty-source": true,
     "no-extra-semicolons": true,
-    "no-unknown-animations": true,
     "prettier/prettier": true,
     "property-case": "lower",
     "property-no-unknown": true,


### PR DESCRIPTION
This rule enforces that identifiers of @keyframes CSS animations should live within the same source (file). 
I think we don't need this rule, as we like to declare global CSS animations as well. These could live in different sources. Therefore I'd like to propose that we remove this particular default linting rule.

See also:
https://stylelint.io/user-guide/rules/list/no-unknown-animations/